### PR TITLE
Update spec.md

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -8,7 +8,7 @@ title: RPC spec versions
 
 The RPC service will support only the latest and the previous versions of the RPC spec. Specifying the spec version on the path is optional but recommended.
 
-Use `v0_5` on the path to specify version `v0.5.0`.
+Use `rpc/v0_5` on the path to specify version `v0.5.0`.
 
 ### Latest version
 
@@ -30,7 +30,7 @@ curl --location 'https://limited-rpc.nethermind.io/mainnet-juno/' \
 To request a specific version of the spec, you can add it to the path, like this. This way there's no doubt which spec version you're calling, but you'll need to keep up with new spec versions as we support them.
 
 ```bash
-curl --location 'https://limited-rpc.nethermind.io/mainnet-juno/v0_5' \
+curl --location 'https://limited-rpc.nethermind.io/mainnet-juno/rpc/v0_5' \
 --data '{
 	"jsonrpc":"2.0",
 	"method":"starknet_specVersion",


### PR DESCRIPTION
Updated the path to specify a spec version to `rpc/vX_Y` to have a unified format for all full node implementations.